### PR TITLE
Handle case-sensitive column names

### DIFF
--- a/source/sp-alter-column.sql
+++ b/source/sp-alter-column.sql
@@ -590,8 +590,8 @@ AS BEGIN
       ,sqltext
     )
     SELECT
-      Stat.schemaname
-      ,Stat.tablename
+      Stat.SchemaName
+      ,Stat.TableName
       ,'STATS' AS objecttype
       ,'C' AS operationtype
       ,Stat.SQLStr + ')'
@@ -740,7 +740,7 @@ AS BEGIN
       JOIN
         sys.objects AS O ON (O.object_id=Create_Indexes.object_id)
       WHERE
-        (Create_Indexes.RowType='R')
+        (Create_Indexes.rowtype='R')
       GROUP BY
         Create_Indexes.object_id
         ,Create_Indexes.index_id


### PR DESCRIPTION
When trying to add this stored proc to my db, I was getting errors:
{{{
Msg 207, Level 16, State 1, Procedure sp_alter_column, Line 575 [Batch Start Line 18]
Invalid column name 'schemaname'.
Msg 207, Level 16, State 1, Procedure sp_alter_column, Line 576 [Batch Start Line 18]
Invalid column name 'tablename'.
Msg 207, Level 16, State 1, Procedure sp_alter_column, Line 725 [Batch Start Line 18]
Invalid column name 'RowType'.
}}}
Probably to do with case-sensitivity of column names.

This PR resolves the errors to get the stored proc to add